### PR TITLE
Add quickmode

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -17,6 +17,7 @@ setmetatable(_detail.player_data, {
 	__index = function(self, playername)
 		self[playername] = {
 			activated = true,
+			quickmode = false,
 			association = {},
 		}
 		return self[playername]

--- a/command.lua
+++ b/command.lua
@@ -11,7 +11,7 @@ minetest.register_chatcommand("digall:deactivate", {
 	privs = { digall = true },
 	func = function(name)
 		return digall.deactivate(name)
-	end
+	end,
 })
 
 minetest.register_chatcommand("digall:init", {
@@ -21,7 +21,21 @@ minetest.register_chatcommand("digall:init", {
 		digall._detail.player_data[name].association = {}
 		digall.set_default_association(name)
 		return true, "initialized."
-	end
+	end,
+})
+
+minetest.register_chatcommand("digall:quickmode", {
+	description = "Quick mode toggle",
+	privs = { digall = true },
+	func = function(name)
+		if digall._detail.player_data[name].quickmode then
+			digall._detail.player_data[name].quickmode = false
+			return true, "Disable quick mode."
+		else
+			digall._detail.player_data[name].quickmode = true
+			return true, "Enable quick mode."
+		end
+	end,
 })
 
 local _player_formspec = {}

--- a/init.lua
+++ b/init.lua
@@ -9,6 +9,13 @@ local function _digall(pos, oldnode, oldmetadata, digger)
 		return
 	end
 
+	if pdata.quickmode then
+		local control = digger:get_player_control()
+		if not control.sneak then
+			return
+		end
+	end
+
 	local state = oldmetadata.fields["digall"]
 	if state and state == "1" then -- already reserved
 		return


### PR DESCRIPTION
Adds quickmode.

If quickmode is enabled, players will only have digall enabled if they dug node in sneaky state.
You do not have to enter the activate / deactivate command every time.

Quickmode is enabled with the __digall:quick__ command.