### PR TITLE
Fix player_data bug and set default deactivated #8 #9

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -13,16 +13,6 @@ function _detail.dig_node_common(pos, node, meta, digger)
 end
 
 _detail.player_data = {}
-setmetatable(_detail.player_data, {
-	__index = function(self, playername)
-		self[playername] = {
-			activated = true,
-			quickmode = false,
-			association = {},
-		}
-		return self[playername]
-	end
-})
 
 --- Activates digall of the player.
 function digall.activate(playername)

--- a/init.lua
+++ b/init.lua
@@ -68,11 +68,21 @@ minetest.after(0, function()
 end)
 
 minetest.register_on_newplayer(function(player)
+	digall._detail.player_data[player:get_player_name()] = {
+		activated = false,
+		quickmode = false,
+		association = {},
+	}
 	digall.set_default_association(player:get_player_name())
 end)
 
 minetest.register_on_joinplayer(function(player)
 	if not rawget(digall._detail.player_data, player:get_player_name()) then
+		digall._detail.player_data[player:get_player_name()] = {
+			activated = false,
+			quickmode = false,
+			association = {},
+		}
 		digall.set_default_association(player:get_player_name())
 	end
 end)


### PR DESCRIPTION
* Make player_data initialization explicitly
* New players are deactivated in order to prohibit non-priv user from digall.